### PR TITLE
Preset button colour selector fix

### DIFF
--- a/Source/ColourEditComponent.h
+++ b/Source/ColourEditComponent.h
@@ -156,7 +156,7 @@ public:
 
     void resetToLastUpdated(bool sendSelectorListenerUpdate = true);
 
-    Colour getLastUpdatedColour();
+    Colour getLastUpdatedColour() const;
 
     // ColourSelectionBroadcaster Implementation
     Colour getSelectedColour() override;

--- a/Source/ColourPaletteWindow.cpp
+++ b/Source/ColourPaletteWindow.cpp
@@ -70,9 +70,6 @@ ColourPaletteWindow::~ColourPaletteWindow()
     paletteEditPanel        = nullptr;
     newPaletteVisual        = nullptr;
     newPaletteButton        = nullptr;
-
-    // Let MainComponent know this is closed
-    sendChangeMessage();
 }
 
 int ColourPaletteWindow::createAndListenToPaletteControls(LumatoneColourPalette& paletteIn)

--- a/Source/ColourPaletteWindow.h
+++ b/Source/ColourPaletteWindow.h
@@ -21,10 +21,11 @@
 */
 class ColourPaletteWindow  :    public juce::Component,
                                 public Button::Listener,
-                                public ChangeListener
+                                public ChangeListener,
+                                public ChangeBroadcaster
 {
 public:
-    ColourPaletteWindow(Array<LumatoneColourPalette>& colourPalettesIn, ColourSelectionGroup* selectionGroupIn = nullptr);
+    ColourPaletteWindow(Array<LumatoneColourPalette>& colourPalettesIn);
     ~ColourPaletteWindow() override;
 
     void resized() override;
@@ -33,6 +34,14 @@ public:
 
     void changeListenerCallback(ChangeBroadcaster* source) override;
 
+    //====================================================================
+
+    /// <summary>
+    /// Registers a listener to receive the colour the user's input resolves to
+    /// </summary>
+    /// <param name="listenerIn"></param>
+    void listenToColourSelection(ColourSelectionListener* listenerIn) { paletteGroup.addColourSelectionListener(listenerIn); }
+
 private:
 
     /// <summary>
@@ -40,7 +49,7 @@ private:
     /// </summary>
     /// <param name="coloursIn"></param>
     /// <returns>Index of new palette</returns>
-    int createAndListenToPaletteGroup(LumatoneColourPalette& paletteIn);
+    int createAndListenToPaletteControls(LumatoneColourPalette& paletteIn);
 
     /// <summary>
     /// Launches the Palette Edit panel and listens for user interaction.
@@ -67,7 +76,7 @@ private:
 
     std::unique_ptr<Viewport> palettePanelViewport;
 
-    ColourSelectionGroup* paletteGroup;
+    ColourSelectionGroup paletteGroup;
 
     OwnedArray<PaletteControlGroup> filledPalettes;
     std::unique_ptr<ColourPaletteComponent> newPaletteVisual;

--- a/Source/ColourPaletteWindow.h
+++ b/Source/ColourPaletteWindow.h
@@ -21,8 +21,7 @@
 */
 class ColourPaletteWindow  :    public juce::Component,
                                 public Button::Listener,
-                                public ChangeListener,
-                                public ChangeBroadcaster
+                                public ChangeListener
 {
 public:
     ColourPaletteWindow(Array<LumatoneColourPalette>& colourPalettesIn);

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -57,15 +57,6 @@ MainContentComponent::MainContentComponent()
 	changeListenerCallback(noteEditArea->getOctaveBoardSelectorTab());
 
 	noteEditArea->changeSingleKeySelection(0);
-
-
-	// Connect colour selectors
-	colourSelectionGroup.reset(new ColourSelectionGroup());
-	colourSelectionGroup->addColourSelectionListener(noteEditArea->getColourEditComponent());
-
-	auto colourTextEditor = noteEditArea->getSingleNoteColourTextEditor();
-	colourSelectionGroup->addColourSelectionListener(colourTextEditor);
-	colourSelectionGroup->addSelector(colourTextEditor);
 }
 
 MainContentComponent::~MainContentComponent()
@@ -315,14 +306,23 @@ void MainContentComponent::changeListenerCallback(ChangeBroadcaster *source)
 
 void MainContentComponent::buttonClicked(Button* btn)
 {
-	// If this resolves, colour palette window was requested
-	ColourEditComponent* colourEdit = dynamic_cast<ColourEditComponent*>(btn);
+	ColourEditComponent* colourEdit = nullptr;
+
+	if (btn == noteEditArea->getColourEditComponent())
+	{
+		colourEdit = noteEditArea->getColourEditComponent();
+	}
+	else
+	{
+		// If this resolves, a preset button colour button was pressed
+		colourEdit = dynamic_cast<ColourEditComponent*>(btn);
+	}
 
 	if (colourEdit)
 	{
-		// TODO: Set swatch # or custom colour as current colour
-		ColourPaletteWindow* paletteWindow = new ColourPaletteWindow(TerpstraSysExApplication::getApp().getColourPalettes(), colourSelectionGroup.get());
+		ColourPaletteWindow* paletteWindow = new ColourPaletteWindow(TerpstraSysExApplication::getApp().getColourPalettes());
 		paletteWindow->setSize(proportionOfWidth(popupWidth), proportionOfHeight(popupHeight));
+		paletteWindow->listenToColourSelection(colourEdit);
 
 		Rectangle<int> componentArea = colourEdit->getScreenBounds().translated(-getScreenX(), -getScreenY());
 
@@ -333,6 +333,7 @@ void MainContentComponent::buttonClicked(Button* btn)
 		);
 
 		popupBox.setLookAndFeel(&getLookAndFeel());
+		// TODO: Set swatch # or custom colour as current colour
 	}
 }
 

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -306,22 +306,20 @@ void MainContentComponent::changeListenerCallback(ChangeBroadcaster *source)
 
 void MainContentComponent::buttonClicked(Button* btn)
 {
-	ColourEditComponent* colourEdit = nullptr;
-
-	if (btn == noteEditArea->getColourEditComponent())
-	{
-		colourEdit = noteEditArea->getColourEditComponent();
-	}
-	else
-	{
-		// If this resolves, a preset button colour button was pressed
-		colourEdit = dynamic_cast<ColourEditComponent*>(btn);
-	}
+	ColourEditComponent* colourEdit = dynamic_cast<ColourEditComponent*>(btn);
 
 	if (colourEdit)
 	{
 		ColourPaletteWindow* paletteWindow = new ColourPaletteWindow(TerpstraSysExApplication::getApp().getColourPalettes());
 		paletteWindow->setSize(proportionOfWidth(popupWidth), proportionOfHeight(popupHeight));
+
+		if (btn == noteEditArea->getColourEditComponent())
+		{
+			colourEdit = noteEditArea->getColourEditComponent();
+			paletteWindow->listenToColourSelection(noteEditArea->getSingleNoteColourTextEditor());
+		}
+		// else, a preset button colour button was pressed
+
 		paletteWindow->listenToColourSelection(colourEdit);
 
 		Rectangle<int> componentArea = colourEdit->getScreenBounds().translated(-getScreenX(), -getScreenY());

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -109,9 +109,6 @@ private:
 	// Buffer for copy/paste of sub board data
 	TerpstraKeys		copiedSubBoardData;
 
-	// Listening system to broadcast key selection changes with multiple selection types available
-	std::unique_ptr<ColourSelectionGroup> colourSelectionGroup;
-
 	//==============================================================================
 	// Position and Size helpers
 

--- a/Source/SingleNoteAssign.cpp
+++ b/Source/SingleNoteAssign.cpp
@@ -111,7 +111,7 @@ SingleNoteAssign::SingleNoteAssign ()
 
 
     //[UserPreSize]
-    colourTextEditor.reset(new ColourTextEditor("colourTextEditor", "ff60aac5")); // TODO: load last active colour?
+    colourTextEditor.reset(new ColourTextEditor("colourTextEditor", "60aac5")); // TODO: load last active colour?
     addAndMakeVisible(colourTextEditor.get());
     colourTextEditor->addColourSelectionListener(this);
     //[/UserPreSize]

--- a/Source/SingleNoteAssign.cpp
+++ b/Source/SingleNoteAssign.cpp
@@ -113,6 +113,7 @@ SingleNoteAssign::SingleNoteAssign ()
     //[UserPreSize]
     colourTextEditor.reset(new ColourTextEditor("colourTextEditor", "ff60aac5")); // TODO: load last active colour?
     addAndMakeVisible(colourTextEditor.get());
+    colourTextEditor->addColourSelectionListener(this);
     //[/UserPreSize]
 
 
@@ -378,6 +379,12 @@ void SingleNoteAssign::lookAndFeelChanged()
         lookAndFeel->setupComboBox(*keyTypeCombo);
         lookAndFeel->setupTextEditor(*colourTextEditor);
     }
+}
+
+void SingleNoteAssign::colourChangedCallback(ColourSelectionBroadcaster* source, Colour newColour)
+{
+    if (source == colourTextEditor.get())
+        colourSubwindow->setColour(colourTextEditor->getText());
 }
 
 /// <summary>Called from parent when one of the keys is clicked</summary>

--- a/Source/SingleNoteAssign.h
+++ b/Source/SingleNoteAssign.h
@@ -39,7 +39,8 @@
 class SingleNoteAssign  : public Component,
                           public juce::ComboBox::Listener,
                           public juce::Button::Listener,
-                          public juce::TextEditor::Listener
+                          public juce::TextEditor::Listener,
+                          public ColourSelectionListener
 {
 public:
     //==============================================================================
@@ -59,6 +60,9 @@ public:
     ColourEditComponent* getColourEditComponent() { return colourSubwindow.get(); }
     ColourTextEditor* getColourTextEditor() { return colourTextEditor.get(); }
 
+    virtual void textEditorFocusLost(TextEditor&) {}
+
+    void colourChangedCallback(ColourSelectionBroadcaster* source, Colour newColour) override;
     //[/UserMethods]
 
     void paint (juce::Graphics& g) override;


### PR DESCRIPTION
This fixes the conflict between the SingleNoteAssign colour selector and the Preset Button colour selectors. It also restricts the ColourTextEditor in SingleNoteAssign to 6 characters for RGB.